### PR TITLE
EvseV2G: minor fixes, simplify logging

### DIFF
--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -266,7 +266,7 @@ void ISO15118_chargerImpl::handle_certificate_response(
         v2g_ctx->evse_v2g_data.cert_install_res_b64_buffer = std::string(exi_stream_status.exiResponse.value());
     }
     v2g_ctx->evse_v2g_data.cert_install_status =
-        (exi_stream_status.status == types::iso15118_charger::Status::Accepted) ? true : false;
+        (exi_stream_status.status == types::iso15118_charger::Status::Accepted);
     pthread_cond_signal(&v2g_ctx->mqtt_cond);
     /* unlock */
     pthread_mutex_unlock(&v2g_ctx->mqtt_lock);

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -211,15 +211,15 @@ static int debug_verify_cert(void* data, mbedtls_x509_crt* crt, int depth, uint3
     char buf[1024];
     ((void)data);
 
-    dlog(DLOG_LEVEL_INFO, "\nVerify requested for (Depth %d):\n", depth);
+    dlog(DLOG_LEVEL_INFO, "Verify requested for (Depth %d):", depth);
     mbedtls_x509_crt_info(buf, sizeof(buf) - 1, "", crt);
     dlog(DLOG_LEVEL_INFO, "%s", buf);
 
     if ((*flags) == 0)
-        dlog(DLOG_LEVEL_INFO, "  This certificate has no flags\n");
+        dlog(DLOG_LEVEL_INFO, "  This certificate has no flags");
     else {
         mbedtls_x509_crt_verify_info(buf, sizeof(buf), "  ! ", *flags);
-        dlog(DLOG_LEVEL_INFO, "%s\n", buf);
+        dlog(DLOG_LEVEL_INFO, "%s", buf);
     }
 
     return (0);

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -195,7 +195,7 @@ static bool load_contract_root_cert(mbedtls_x509_crt* contract_root_crt, const c
         }
     }
 
-    return (rv != 0) ? false : true;
+    return (rv == 0);
 }
 
 /*!

--- a/modules/EvseV2G/log.cpp
+++ b/modules/EvseV2G/log.cpp
@@ -5,69 +5,18 @@
 #include <everest/logging.hpp> // for logging
 #include <stdarg.h>            // for va_list, va_{start,end}()
 #include <stdio.h>             // for v*printf()
-#include <stdlib.h>            // for atoi()
-#include <string.h>            // for strlen()
-#include <sys/time.h>          // for gettimeofday()
-#include <time.h>              // for strftime()
 
-dloglevel_t minloglevel_current = DLOG_LEVEL_INFO;
-
-static const char* debug_level_logstring_map[DLOG_LEVEL_NUMLEVELS] = {
-    // tailing space, no need to add it later when printing
-    // try to keep the strings almost same length, looks better
-    "[(LOG)] ", "[ERROR] ", "[WARN]  ", "[INFO]  ", "[DEBUG] ", "[TRACE] "};
-
-const char* debug_level_mqtt_string_map[DLOG_LEVEL_NUMLEVELS] = {"always", "error", "warning",
-                                                                 "info",   "debug", "trace"};
-
-// FIXME: inline?
-void dlog_func(const dloglevel_t loglevel, const char* filename, const int linenumber, const char* functionname,
-               const char* format, ...) {
-    // fast exit
-    if (loglevel > minloglevel_current) {
-        return;
-    }
+void dlog(const dloglevel_t loglevel, const char* format, ...) {
     char* format_copy = NULL;
-    FILE* outstream = stderr; // change output target here, if desired
-
-    struct timeval debug_tval;
-    struct tm tm;
-    char log_datetimestamp[16];      // length due to format [00:00:00.000], rounded up to fit 32-bit alignment
-    gettimeofday(&debug_tval, NULL); // ignore return value
-    size_t offset =
-        strftime(log_datetimestamp, sizeof(log_datetimestamp), "[%H:%M:%S", gmtime_r(&debug_tval.tv_sec, &tm));
-    if (offset < 1) {
-        // in our use of strftime(), this is an error
-        return;
-    }
-
-    snprintf(log_datetimestamp + offset, sizeof(log_datetimestamp) - offset, ".%03ld] ", debug_tval.tv_usec / 1000);
-
     va_list args;
-    va_start(args, format);
 
-    // print the user given part
-    // strip possible newline character from user-given string
-    // FIXME: could be skipped
-    if (format) {
-        size_t formatlen = std::string(format).size();
-        format_copy = static_cast<char*>(calloc(1, formatlen + 1)); // additional byte for terminating \0
-        memcpy(format_copy, format, formatlen);
-        if ((formatlen >= 1) && (format_copy[formatlen - 1] == '\n')) {
-            format_copy[formatlen - 1] = '\0';
-        }
+    va_start(args, format);
+    char output[1024] = "\0";
+
+    if (format != NULL) {
+        vsnprintf(output, sizeof(output), format, args);
     }
-    char output[256];
-    if (format_copy != NULL) {
-        vsnprintf(output, sizeof(output), format_copy, args);
-    }
-    // force EOL
-    fputs("\n", outstream);
-    fflush(outstream);
     va_end(args);
-    if (format_copy) {
-        free(format_copy);
-    }
 
     switch (loglevel) {
     case DLOG_LEVEL_ERROR:
@@ -89,43 +38,4 @@ void dlog_func(const dloglevel_t loglevel, const char* filename, const int linen
         EVLOG_critical << "Unknown log level";
         break;
     }
-}
-
-void dlog_level_inc(void) {
-    dloglevel_t minloglevel_new = (dloglevel_t)((int)minloglevel_current + 1);
-    if (minloglevel_new == DLOG_LEVEL_NUMLEVELS) {
-        // wrap to bottom, but not DLOG_LEVEL_ALWAYS
-        minloglevel_new = DLOG_LEVEL_ERROR;
-    }
-    dlog_level_set(minloglevel_new);
-}
-
-void dlog_level_set(const dloglevel_t loglevel) {
-    // no sanity checks currently
-    const dloglevel_t minloglevel_old = minloglevel_current;
-    dloglevel_t newloglevel = loglevel;
-    if (newloglevel >= DLOG_LEVEL_NUMLEVELS) {
-        // set something illegally high
-        newloglevel = (dloglevel_t)(int)(DLOG_LEVEL_NUMLEVELS - 1);
-    }
-    if (newloglevel <= DLOG_LEVEL_ALWAYS) {
-        // set something illegally low
-        newloglevel = (dloglevel_t)(int)(DLOG_LEVEL_ALWAYS + 1);
-    }
-    if (newloglevel != minloglevel_current) {
-        minloglevel_current = newloglevel;
-        dlog(DLOG_LEVEL_ALWAYS, "switched log level from %d (\"%s\") to %d (\"%s\")", minloglevel_old,
-             debug_level_logstring_map[minloglevel_old], newloglevel, debug_level_logstring_map[newloglevel]);
-    }
-}
-
-dloglevel_t dlog_level_get(void) {
-    return minloglevel_current;
-}
-
-static const char* dlog_level_get_string(const dloglevel_t loglevel) {
-    if ((loglevel < 1) || loglevel >= DLOG_LEVEL_NUMLEVELS) {
-        return "invalid_level";
-    }
-    return debug_level_mqtt_string_map[loglevel];
 }

--- a/modules/EvseV2G/log.hpp
+++ b/modules/EvseV2G/log.hpp
@@ -18,45 +18,6 @@ typedef enum dloglevel_t {
 } dloglevel_t;
 
 /**
- * @brief Internal: Issue a log message. Please use the dlog() macro instead.
- *
- * @return void
- */
-void dlog_func(const dloglevel_t loglevel, const char* filename, const int linenumber, const char* functionname,
-               const char* format, ...);
-
-/**
- * @brief Increase the log level to the next higher step (more messages). At the highest step, the level rolls over to
- * the lowest.
- *
- * @return void
- */
-void dlog_level_inc(void);
-
-/**
- * @brief Set the log level.
- * @param[in] loglevel the log level the logger shall use, of type enum dloglevel
- *
- * @return void
- */
-void dlog_level_set(const dloglevel_t loglevel);
-
-/**
- * @brief Get the log level.
- *
- * @return dloglevel_t the currently valid log level
- */
-dloglevel_t dlog_level_get(void);
-
-/**
- * @brief Set the log level from an MQTT topic string.
- * @param[in] loglevel the log level the logger shall use, as an MQTT string
- *
- * @return void
- */
-// dloglevel_t dlog_level_set_from_mqtt_string(const char *level_string);
-
-/**
  * @brief Issue a log message.
  *
  * @param[in] level the log level this message belongs to (type enum dloglevel)
@@ -64,10 +25,5 @@ dloglevel_t dlog_level_get(void);
  *
  * @return void
  */
-// this is a macro, so that when dlog() is used, it gets expanded at the caller's location
-#define dlog(level, ...)                                                                                               \
-    do {                                                                                                               \
-        dlog_func((level), __FILE__, __LINE__, __func__, ##__VA_ARGS__);                                               \
-    } while (0)
-
+void dlog(const dloglevel_t loglevel, const char* format, ...);
 #endif /* LOG_H */


### PR DESCRIPTION
DRAFT - DO NOT MERGE

I just want an internal review, before I put up a pull request against upstream.

## Describe your changes
The EvseV2G module still uses our old truffle `dlog()` infrastructure. This has become overkill, as its particular features are unused (file names and line numbers, changing log level at runtime). Furthermore, string concatenations and timestamp calculations are still being done though never used!

This PR strips everything which is not used from the log functions, and converts `dlog()` from a macro to a function. `dlog()` is now a simple converter from C-printf-style logging to `EVLOG_*` streams.

Also, some very minor logic simplifications are made, without impact on the compiled code.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

